### PR TITLE
Implemented utility to work with Request parameters

### DIFF
--- a/lib/src/main/java/com/github/tonivade/claudb/command/CommandException.java
+++ b/lib/src/main/java/com/github/tonivade/claudb/command/CommandException.java
@@ -1,0 +1,21 @@
+package com.github.tonivade.claudb.command;
+
+import com.github.tonivade.resp.protocol.AbstractRedisToken.ErrorRedisToken;
+
+/**
+ * Root exception for all problems which happens during command execution.
+ * If happens it will be automatically converted into {@link ErrorRedisToken} and send in response.
+ */
+public class CommandException extends RuntimeException {
+  public CommandException(String message) {
+    super(message);
+  }
+
+  public CommandException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public CommandException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/lib/src/main/java/com/github/tonivade/claudb/command/DBCommandWrapper.java
+++ b/lib/src/main/java/com/github/tonivade/claudb/command/DBCommandWrapper.java
@@ -78,10 +78,15 @@ public class DBCommandWrapper implements RespCommand {
       enqueueRequest(request);
       return status("QUEUED");
     }
-    if (command instanceof DBCommand) {
-      return executeDBCommand(db, request);
-    } else if (command instanceof RespCommand) {
-      return executeCommand(request);
+
+    try {
+      if (command instanceof DBCommand) {
+        return executeDBCommand(db, request);
+      } else if (command instanceof RespCommand) {
+        return executeCommand(request);
+      }
+    } catch (CommandException e) {
+      return error("ERR " + e.getMessage());
     }
     return error("invalid command type: " + command.getClass());
   }

--- a/lib/src/main/java/com/github/tonivade/claudb/command/ParamsScanner.java
+++ b/lib/src/main/java/com/github/tonivade/claudb/command/ParamsScanner.java
@@ -1,0 +1,220 @@
+package com.github.tonivade.claudb.command;
+
+import com.github.tonivade.claudb.glob.GlobPattern;
+import com.github.tonivade.resp.command.Request;
+import com.github.tonivade.resp.protocol.SafeString;
+
+import java.util.function.Function;
+
+/**
+ * A utility class to parse command parameters from a {@link Request}.
+ * This class maintains an internal index to track parameter consumption
+ * and provides methods for sequential and named parameter parsing.
+ * All parameters are validated during access, and {@link CommandException} is thrown
+ * if the expected arguments are missing, invalid, or misplaced.
+ */
+public final class ParamsScanner {
+  private final Request request;
+  private int index = 0;
+
+  public ParamsScanner(Request request) {
+    this.request = request;
+  }
+
+  /**
+   * @return the number of unprocessed parameters.
+   */
+  public int remaining() {
+    return request.getLength() - index;
+  }
+
+  /**
+   * @return true if there are more unaccessed parameters; false otherwise
+   */
+  public boolean hasNext() {
+    return index < request.getLength();
+  }
+
+  /**
+   * Ensures that there are unprocessed parameters,
+   * and throws {@link CommandException } if there are no unprocessed parameters.
+   */
+  public void verifyHasNext() {
+    if (index >= request.getLength()) {
+      throw new CommandException("Wrong number of arguments, expected more arguments");
+    }
+  }
+
+  /**
+   * Ensures that there are no more unprocessed parameters,
+   * and throws {@link CommandException } if there are unprocessed parameters.
+   */
+  public void verifyHasNoMore() {
+    if (index < request.getLength()) {
+      throw new CommandException("Wrong number of arguments, no more arguments expected");
+    }
+  }
+
+  /**
+   * Checks if there are more parameters available and if the next parameter matches the given value.
+   * In other words, this method checks that string representation of the next parameter is equal to the {@code value}.
+   *
+   * @param value expected value for the next parameter ignoring a case.
+   * @return true if there are unaccessed parameters and the next parameter matches the given name; false otherwise.
+   *
+   * @see #hasNext()
+   */
+  public boolean hasNext(String value) {
+    return index < request.getLength() && value.equalsIgnoreCase(request.getParam(index).toString());
+  }
+
+  /**
+   * Consumes one next unprocessed parameter and returns it as a {@link String}.
+   * If there are no more parameters to process, {@link CommandException} is thrown.
+   *
+   * @return the string representation of the next unprocessed parameter.
+   */
+  public String nextString() {
+    return getValue(SafeString::toString);
+  }
+
+  /**
+   * Consumes two next unprocessed parameters and validates that the first parameter matches {@code name}
+   * and returns the second parameter as a {@link String}.
+   * If the name does not match or if there are no unprocessed parameters available,
+   * a {@link CommandException} is thrown.
+   * <p>
+   * Speaking simply, it is intended to parse pais of parameter where
+   * the first parameter is a name and the second is a value.
+   * For example, it can be used to parse the command:<br>
+   * {@code HELLO SETNAME redis-cli}
+   * <pre>
+   * {@code String clientName = paramsScanner.nextString("SETNAME");}
+   * </pre>
+   *
+   * @param name the expected name of the next parameter
+   *
+   * @return the {@link String} representation of the second consumed parameter.
+   * @throws CommandException if the next parameter's name does not match the given name,
+   *                          or if there are no more parameters to process.
+   */
+  public String nextString(String name) {
+    return getNamedValue(name, SafeString::toString);
+  }
+
+  /**
+   * Similar as {@link #nextString(String)} but returns a default value if the parameter is missing.
+   *
+   * @param name the expected name of the next parameter
+   * @param defValue the default value to return if there is only one unprocessed parameter.
+   *
+   * @return the {@link String} representation of the second consumed parameter or the default value.
+   * @throws CommandException if the next parameter's name does not match the given name.
+   * @see #nextString(String)
+   */
+  public String nextString(String name, String defValue) {
+    return getOptionalNamedValue(name, defValue, SafeString::toString);
+  }
+
+  /**
+   * Similar as {@link #nextString()} but returns an integer value.
+   *
+   * @return the integer value of the next unprocessed parameter,
+   * or throws {@link CommandException} if the parameter is not an integer or missing.
+   *
+   * @see #nextString()
+   */
+  public int nextInt() {
+    return getValue(ParamsScanner::parseInt);
+  }
+
+  /**
+   * Similar as {@link #nextString(String)} but returns an integer value.
+   * @see #nextString(String)
+   */
+  public int nextInt(String name) {
+    return getNamedValue(name, ParamsScanner::parseInt);
+  }
+
+  /**
+   * Similar as {@link #nextString(String, String)} but returns an integer value.
+   * @see #nextString(String, String)
+   */
+  public int nextInt(String name, int defValue) {
+    return getOptionalNamedValue(name, defValue, ParamsScanner::parseInt);
+  }
+
+  /**
+   * Similar as {@link #nextString()} but returns a {@link GlobPattern} value.
+   * @see #nextString()
+   */
+  public GlobPattern nextGlob() {
+    return new GlobPattern(nextString());
+  }
+
+  /**
+   * Similar as {@link #nextString(String)} but returns a {@link GlobPattern} value.
+   * @see #nextString(String)
+   */
+  public GlobPattern nextGlob(String name) {
+    return new GlobPattern(nextString(name));
+  }
+
+  /**
+   * Similar as {@link #nextString(String, String)} but returns a {@link GlobPattern} value.
+   * @see #nextString(String, String)
+   */
+  public GlobPattern nextGlob(String name, String defValue) {
+    return new GlobPattern(nextString(name, defValue));
+  }
+
+  private <T> T getValue(Function<SafeString, T> converter) {
+    if (request.getLength() <= index) {
+      throw new CommandException("Wrong number of arguments, expected more arguments");
+    }
+    T result = converter.apply(request.getParam(index));
+    index++;
+    return result;
+  }
+
+  private <T> T getNamedValue(String name, Function<SafeString, T> extractor) {
+    if (request.getLength() <= index) {
+      throw new CommandException("Expected parameter named '" + name + "' is missing");
+    }
+    SafeString actualName = request.getParam(index);
+    if (!name.equalsIgnoreCase(actualName.toString())) {
+      throw new CommandException("Expected parameter named '" + name + "', but found '" + actualName + "'");
+    }
+    if (request.getLength() <= index + 1) {
+      throw new CommandException("Value for parameter '" + name + "' is missing");
+    }
+    T result = extractor.apply(request.getParam(index + 1));
+    index += 2;
+    return result;
+  }
+
+  private <T> T getOptionalNamedValue(String name, T defValue, Function<SafeString, T> extractor) {
+    if (request.getLength() <= index) {
+      return defValue;
+    }
+    SafeString actualName = request.getParam(index);
+    if (!name.equalsIgnoreCase(actualName.toString())) {
+      return defValue;
+    }
+    if (request.getLength() <= index + 1) {
+      throw new CommandException("Value for parameter '" + name + "' is missing");
+    }
+    T result = extractor.apply(request.getParam(index + 1));
+    index += 2;
+    return result;
+  }
+
+  private static Integer parseInt(SafeString str) {
+    try {
+      return Integer.parseInt(str.toString());
+    } catch (NumberFormatException e) {
+      throw new CommandException("Value is not an integer or out of range");
+    }
+  }
+
+}

--- a/lib/src/main/java/com/github/tonivade/claudb/glob/GlobPattern.java
+++ b/lib/src/main/java/com/github/tonivade/claudb/glob/GlobPattern.java
@@ -9,15 +9,23 @@ import static java.util.regex.Pattern.compile;
 import java.util.regex.Pattern;
 
 public class GlobPattern {
-  
+  private final String rawPattern;
   private final Pattern pattern;
-  
+
   public GlobPattern(String pattern) {
+    this.rawPattern = pattern;
     this.pattern = compile(convertGlobToRegEx(pattern));
   }
-  
+
   public boolean match(String value) {
     return pattern.matcher(value).matches();
+  }
+
+  /**
+   * @return the original string pattern used to create this {@link GlobPattern} instance.
+   */
+  public String pattern() {
+    return rawPattern;
   }
 
   /*

--- a/lib/src/test/java/com/github/tonivade/claudb/command/ParamsScannerTest.java
+++ b/lib/src/test/java/com/github/tonivade/claudb/command/ParamsScannerTest.java
@@ -1,0 +1,270 @@
+package com.github.tonivade.claudb.command;
+
+import com.github.tonivade.resp.command.DefaultRequest;
+import com.github.tonivade.resp.command.Request;
+import com.github.tonivade.resp.protocol.SafeString;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+public class ParamsScannerTest {
+
+  static final String TEST_NAME1 = "Test-Name-One";
+  static final String TEST_NAME1_LOWER = TEST_NAME1.toLowerCase(Locale.ROOT);
+  static final String TEST_NAME2 = "Test-Name-Two";
+  static final String TEST_NAME2_LOWER = TEST_NAME2.toLowerCase(Locale.ROOT);
+  static final String TEST_NAME3 = "Test-Name-Three";
+  static final String TEST_STRING_VAL1 = "Test-String-Value-One";
+  static final String TEST_STRING_VAL2 = "Test-String-Value-Two";
+  static final String TEST_GLOB_VAL1 = "test:glob:one:*";
+  static final String TEST_GLOB_VAL2 = "test:glob:two:*";
+  static final int TEST_INT_VAL1 = 232102;
+  static final int TEST_INT_VAL2 = 535926;
+
+  @Test
+  void prerequisites() {
+    assertNotEquals(TEST_NAME1, TEST_NAME1_LOWER);
+    assertNotEquals(TEST_NAME2, TEST_NAME2_LOWER);
+    assertNotEquals(TEST_NAME1, TEST_NAME2);
+    assertNotEquals(TEST_STRING_VAL1, TEST_STRING_VAL2);
+    assertNotEquals(TEST_INT_VAL1, TEST_INT_VAL2);
+    assertNotEquals(TEST_GLOB_VAL1, TEST_GLOB_VAL2);
+  }
+
+  @Test
+  void remaining() {
+    ParamsScanner someParams = ofParams(TEST_STRING_VAL1, TEST_STRING_VAL1);
+    assertEquals(2, someParams.remaining());
+
+    someParams.nextString();
+    assertEquals(1, someParams.remaining());
+
+    someParams.nextString();
+    assertEquals(0, someParams.remaining());
+  }
+
+  @Test
+  void verifyHasNext() {
+    ParamsScanner someParams = ofParams(TEST_NAME1, TEST_STRING_VAL1);
+    assertDoesNotThrow(someParams::verifyHasNext);
+
+    someParams.nextString();
+    assertDoesNotThrow(someParams::verifyHasNext);
+
+    someParams.nextString();
+    CommandException ex = assertThrows(CommandException.class, someParams::verifyHasNext);
+    assertEquals("Wrong number of arguments, expected more arguments", ex.getMessage());
+  }
+
+  @Test
+  void verifyHasNoMore() {
+    ParamsScanner someParams = ofParams(TEST_NAME1, TEST_STRING_VAL1);
+    CommandException ex = assertThrows(CommandException.class, someParams::verifyHasNoMore);
+    assertEquals("Wrong number of arguments, no more arguments expected", ex.getMessage());
+
+    someParams.nextString();
+    ex = assertThrows(CommandException.class, someParams::verifyHasNoMore);
+    assertEquals("Wrong number of arguments, no more arguments expected", ex.getMessage());
+
+    someParams.nextString();
+    assertDoesNotThrow(someParams::verifyHasNoMore);
+  }
+
+  @Test
+  void hasNext() {
+    ParamsScanner someParams = ofParams(TEST_NAME1, TEST_STRING_VAL1);
+    assertTrue(someParams.hasNext());
+
+    someParams.nextString();
+    assertTrue(someParams.hasNext());
+
+    someParams.nextString();
+    assertFalse(someParams.hasNext());
+  }
+
+  @Test
+  void hasNextValue() {
+    ParamsScanner someParams = ofParams(TEST_STRING_VAL1, TEST_NAME1);
+    assertFalse(someParams.hasNext(TEST_NAME1));
+
+    someParams.nextString();
+    assertTrue(someParams.hasNext(TEST_NAME1));
+    assertTrue(someParams.hasNext(TEST_NAME1_LOWER));
+
+    someParams.nextString();
+    assertFalse(someParams.hasNext(TEST_NAME1));
+    assertFalse(someParams.hasNext(TEST_NAME1_LOWER));
+    someParams.verifyHasNoMore();
+  }
+
+  @Test
+  void nextString() {
+    ParamsScanner someParams = ofParams(TEST_NAME1, TEST_STRING_VAL1);
+    assertEquals(TEST_NAME1, someParams.nextString());
+
+    assertEquals(TEST_STRING_VAL1, someParams.nextString());
+
+    CommandException ex = assertThrows(CommandException.class, someParams::nextString);
+    assertEquals("Wrong number of arguments, expected more arguments", ex.getMessage());
+    someParams.verifyHasNoMore();
+  }
+
+  @Test
+  void nextStringNamed() {
+    ParamsScanner someParams = ofParams(TEST_NAME1, TEST_STRING_VAL1, TEST_NAME2, TEST_STRING_VAL2, TEST_NAME3);
+    CommandException ex = assertThrows(CommandException.class, () -> someParams.nextString(TEST_NAME2));
+    assertEquals("Expected parameter named '" + TEST_NAME2 + "', but found '" + TEST_NAME1 + "'", ex.getMessage());
+
+    assertEquals(TEST_STRING_VAL1, someParams.nextString(TEST_NAME1));
+    assertEquals(TEST_STRING_VAL2, someParams.nextString(TEST_NAME2_LOWER));
+
+    ex = assertThrows(CommandException.class, () -> someParams.nextString(TEST_NAME3));
+    assertEquals("Value for parameter '" + TEST_NAME3 + "' is missing", ex.getMessage());
+
+    assertEquals(TEST_NAME3, someParams.nextString());
+
+    ex = assertThrows(CommandException.class, () -> someParams.nextString(TEST_NAME1));
+    assertEquals("Expected parameter named '" + TEST_NAME1 + "' is missing", ex.getMessage());
+    someParams.verifyHasNoMore();
+  }
+
+  @Test
+  void nextStringNamedDefault() {
+    ParamsScanner someParams = ofParams(TEST_NAME1, TEST_STRING_VAL1, TEST_NAME2);
+    int expectedRemaining = someParams.remaining();
+    assertEquals(TEST_STRING_VAL2, someParams.nextString(TEST_NAME2, TEST_STRING_VAL2), "Default used");
+    assertEquals(expectedRemaining, someParams.remaining(), "Parameters not consumed");
+
+    assertEquals(TEST_STRING_VAL1, someParams.nextString(TEST_NAME1, TEST_STRING_VAL1), "Parameter value used");
+    expectedRemaining -= 2;
+    assertEquals(expectedRemaining, someParams.remaining(), "Two parameters consumed");
+
+    CommandException ex = assertThrows(CommandException.class, () -> someParams.nextString(TEST_NAME2, TEST_STRING_VAL2));
+    assertEquals("Value for parameter '" + TEST_NAME2 + "' is missing", ex.getMessage());
+    assertEquals(expectedRemaining, someParams.remaining(), "Parameters not consumed");
+
+    someParams.nextString();
+    assertEquals(TEST_STRING_VAL2, someParams.nextString(TEST_NAME2, TEST_STRING_VAL2), "Default used again");
+    someParams.verifyHasNoMore();
+  }
+
+  @Test
+  void nextInt() {
+    ParamsScanner someParams = ofParams(TEST_INT_VAL1, TEST_INT_VAL2, TEST_STRING_VAL1);
+    assertEquals(TEST_INT_VAL1, someParams.nextInt());
+    assertEquals(TEST_INT_VAL2, someParams.nextInt());
+
+    CommandException ex = assertThrows(CommandException.class, someParams::nextInt);
+    assertEquals("Value is not an integer or out of range", ex.getMessage());
+
+    assertEquals(TEST_STRING_VAL1, someParams.nextString());
+
+    ex = assertThrows(CommandException.class, someParams::nextInt);
+    assertEquals("Wrong number of arguments, expected more arguments", ex.getMessage());
+    someParams.verifyHasNoMore();
+  }
+
+  @Test
+  void nextIntNamed() {
+    ParamsScanner someParams = ofParams(TEST_NAME1, TEST_INT_VAL1, TEST_NAME2, TEST_INT_VAL2, TEST_NAME3);
+    CommandException ex = assertThrows(CommandException.class, () -> someParams.nextInt(TEST_NAME2));
+    assertEquals("Expected parameter named '" + TEST_NAME2 + "', but found '" + TEST_NAME1 + "'", ex.getMessage());
+
+    assertEquals(TEST_INT_VAL1, someParams.nextInt(TEST_NAME1));
+    assertEquals(TEST_INT_VAL2, someParams.nextInt(TEST_NAME2_LOWER));
+
+    ex = assertThrows(CommandException.class, () -> someParams.nextInt(TEST_NAME3));
+    assertEquals("Value for parameter '" + TEST_NAME3 + "' is missing", ex.getMessage());
+
+    assertEquals(TEST_NAME3, someParams.nextString());
+
+    ex = assertThrows(CommandException.class, () -> someParams.nextInt(TEST_NAME1));
+    assertEquals("Expected parameter named '" + TEST_NAME1 + "' is missing", ex.getMessage());
+    someParams.verifyHasNoMore();
+  }
+
+  @Test
+  void nextIntNamedDefault() {
+    ParamsScanner someParams = ofParams(TEST_NAME1, TEST_INT_VAL1, TEST_NAME2);
+    int expectedRemaining = someParams.remaining();
+    assertEquals(TEST_INT_VAL2, someParams.nextInt(TEST_NAME2, TEST_INT_VAL2), "Default used");
+    assertEquals(expectedRemaining, someParams.remaining(), "Parameters not consumed");
+
+    assertEquals(TEST_INT_VAL1, someParams.nextInt(TEST_NAME1, TEST_INT_VAL1), "Parameter value used");
+    expectedRemaining -= 2;
+    assertEquals(expectedRemaining, someParams.remaining(), "Two parameters consumed");
+
+    CommandException ex = assertThrows(CommandException.class, () -> someParams.nextInt(TEST_NAME2, TEST_INT_VAL2));
+    assertEquals("Value for parameter '" + TEST_NAME2 + "' is missing", ex.getMessage());
+    assertEquals(expectedRemaining, someParams.remaining(), "Parameters not consumed");
+
+    someParams.nextString();
+    assertEquals(TEST_INT_VAL2, someParams.nextInt(TEST_NAME2, TEST_INT_VAL2), "Default used again");
+    someParams.verifyHasNoMore();
+  }
+
+  @Test
+  void nextGlob() {
+    ParamsScanner someParams = ofParams(TEST_GLOB_VAL1, TEST_GLOB_VAL2);
+    assertEquals(TEST_GLOB_VAL1, someParams.nextGlob().pattern());
+    assertEquals(TEST_GLOB_VAL2, someParams.nextGlob().pattern());
+
+    CommandException ex = assertThrows(CommandException.class, someParams::nextInt);
+    assertEquals("Wrong number of arguments, expected more arguments", ex.getMessage());
+    someParams.verifyHasNoMore();
+  }
+
+  @Test
+  void nextGlobNamed() {
+    ParamsScanner someParams = ofParams(TEST_NAME1, TEST_GLOB_VAL1, TEST_NAME2, TEST_GLOB_VAL2, TEST_NAME3);
+    CommandException ex = assertThrows(CommandException.class, () -> someParams.nextGlob(TEST_NAME2));
+    assertEquals("Expected parameter named '" + TEST_NAME2 + "', but found '" + TEST_NAME1 + "'", ex.getMessage());
+
+    assertEquals(TEST_GLOB_VAL1, someParams.nextGlob(TEST_NAME1).pattern());
+    assertEquals(TEST_GLOB_VAL2, someParams.nextGlob(TEST_NAME2_LOWER).pattern());
+
+    ex = assertThrows(CommandException.class, () -> someParams.nextGlob(TEST_NAME3));
+    assertEquals("Value for parameter '" + TEST_NAME3 + "' is missing", ex.getMessage());
+
+    assertEquals(TEST_NAME3, someParams.nextString());
+
+    ex = assertThrows(CommandException.class, () -> someParams.nextGlob(TEST_NAME1));
+    assertEquals("Expected parameter named '" + TEST_NAME1 + "' is missing", ex.getMessage());
+    someParams.verifyHasNoMore();
+  }
+
+  @Test
+  void nextGlobNamedDefault() {
+    ParamsScanner someParams = ofParams(TEST_NAME1, TEST_GLOB_VAL1, TEST_NAME2);
+    int expectedRemaining = someParams.remaining();
+    assertEquals(TEST_GLOB_VAL2, someParams.nextGlob(TEST_NAME2, TEST_GLOB_VAL2).pattern(), "Default used");
+    assertEquals(expectedRemaining, someParams.remaining(), "Parameters not consumed");
+
+    assertEquals(TEST_GLOB_VAL1, someParams.nextGlob(TEST_NAME1, TEST_GLOB_VAL1).pattern(), "Parameter used");
+    expectedRemaining -= 2;
+    assertEquals(expectedRemaining, someParams.remaining(), "Two parameters consumed");
+
+    CommandException ex = assertThrows(CommandException.class, () -> someParams.nextGlob(TEST_NAME2, TEST_GLOB_VAL2));
+    assertEquals("Value for parameter '" + TEST_NAME2 + "' is missing", ex.getMessage());
+    assertEquals(expectedRemaining, someParams.remaining(), "Parameters not consumed");
+
+    someParams.nextString();
+    assertEquals(TEST_GLOB_VAL2, someParams.nextGlob(TEST_NAME2, TEST_GLOB_VAL2).pattern(), "Default used");
+    someParams.verifyHasNoMore();
+  }
+
+  private static ParamsScanner ofParams(Object... values) {
+    List<SafeString> params = Stream.of(values)
+      .map(String::valueOf)
+      .map(SafeString::safeString)
+      .collect(Collectors.toList());
+    Request request = new DefaultRequest(mock(), mock(), mock(), params);
+    return new ParamsScanner(request);
+  }
+}


### PR DESCRIPTION
## Overview
This PR is a proposal, which adds utility classes to simplify implementation of Commands.
Two main ideas can be distinguished:
- `CommandException` - exception which automatically converted into `ErrorRedisToken`.
- `ParamsScanner` - utility to simplify parameters parsing for Redis queries. And it actively throws `CommandException`.

## Example
Parsing Redis command:
```redis
HSCAN key cursor [MATCH pattern] [COUNT count]
```

```java
@Command("hscan")
public class HashScanCommand implements DBCommand {
  public static final int DEFAULT_COUNT = 100;
  public static final String DEFAULT_PATTERN = "*";

  @Override
  public RedisToken execute(Database db, Request request) {
    ParamsScanner parser = new ParamsScanner(request);
    String key = parser.nextString();
    int cursor = parser.nextInt();
    GlobPattern pattern = parser.nextGlob("match", DEFAULT_PATTERN);
    int count = parser.nextInt("count", DEFAULT_COUNT);
    parser.verifyHasNoMore();
```

## Motivation
I tried to implement few Redis commands with bunch of optional parameters.
And code contains a lot of boiler plate `if/else` statements when works with raw `request.getParams()`.
So, at the end I come to utility class which intended to make parameter parsing more concise and readable at the same time.

## Note
It is currently a draft.
Tests, naming and docs are not final yet.

## Related
https://github.com/tonivade/claudb/issues/230
